### PR TITLE
Set PC to 0 after halt instruction

### DIFF
--- a/js/instr.js
+++ b/js/instr.js
@@ -2,6 +2,7 @@ var INSTR = {};
 
 INSTR[0] = function () {
 	STAT = 'HLT';
+	PC = new Long(0);
 	//print("Program halted");
 };
 INSTR[1] = function () {


### PR DESCRIPTION
The Y86 Instruction Set Reference shows that the PC should be set to 0
after a HALT instruction. Currently this is not done, so at the end of
execution the web UI is highlighting the instruction after the halt
which can make it seem like the program just stopped executing.